### PR TITLE
Sign drone.yml.

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -92,3 +92,8 @@ services:
 volumes:
   - name: dockersock
     temp: {}
+---
+kind: signature
+hmac: ab9e6600e4a465bc6c7d9fda3d9d424f1500d61ffa21befd971398cd26465672
+
+...


### PR DESCRIPTION
This makes it more difficult for folks outside of Teleport to make CI
changes and expose any details of internal infrastructure.